### PR TITLE
Fix UI resize freezing from iframe event hijacking

### DIFF
--- a/OneRing/wwwroot/css/home.css
+++ b/OneRing/wwwroot/css/home.css
@@ -139,10 +139,18 @@ h2 {
     height: 2em;
 }
 .portlet-body {
-    /* background-color: cyan; */
     height: calc(100% - 2em);
 }
 
 .grid-stack>.grid-stack-item>.grid-stack-item-content {
     overflow-y: hidden;
+}
+.portlet-overlay {
+    background-color: white;
+    opacity: 0.9;
+    height: calc(100% - 2em);
+    width: 100%;
+    position: absolute;
+    top: 2em;
+    left: 0;
 }

--- a/OneRing/wwwroot/js/home.js
+++ b/OneRing/wwwroot/js/home.js
@@ -32,12 +32,50 @@ require(['lodash', 'jquery', 'gridstack.jQueryUI', 'gridstack'], function(_, $, 
             handle: '.portlet-heading',
         }
     };
+    // disableIframe disables interacting with the iframe portion of portlet by inserting an sibling
+    // element which lays atop that iframe. The positioning of this element is handled in css, but
+    // this overlay element must come before the iframe in the containing div for the overlay to
+    // work.
+    function disableIframe(element) {
+        console.log("disabling iframe", element);
+        let overlay = document.createElement('div');
+        overlay.setAttribute('class', 'portlet-overlay');
+        let body = $(element).find('.portlet-body')[0];
+        body.prepend(overlay);
+        console.log('body: ', body);
+    }
+    // enableIframe enables interacting with the iframe portion of a portlet by removing the
+    // `overlay` element within the gridstack 'window'.
+    function enableIframe(element) {
+        console.log("Enabling iframe!", element);
+        let overlay = $(element).find('.portlet-overlay')[0];
+        overlay.remove();
+    }
 
     $(function () {
         $('.grid-stack').gridstack(options);
         $('.grid-stack').on('change', (event, items) => {
             //console.log(event, items);
             saveDimensions(items);
+        });
+        // Manage iframe interactivity within the portlet being manipulated. When the user starts to
+        // either drage or resize a portlet, disable the iframe of within that portlet. Then, when
+        // the user stops dragging or resizing a portlet, re-enable the iframe within that portlet.
+        $('.grid-stack').on('resizestart', function(event, ui) {
+            let element = event.target;
+            disableIframe(element);
+        });
+        $('.grid-stack').on('resizestop', function(event, ui) {
+            let element = event.target;
+            enableIframe(element);
+        });
+        $('.grid-stack').on('dragstart', function(event, ui) {
+            var element = event.target;
+            disableIframe(element);
+        });
+        $('.grid-stack').on('dragstop', function(event, ui) {
+            var element = event.target;
+            enableIframe(element);
         });
     });
 });


### PR DESCRIPTION
This fix prevents Iframe content of a portlet from hijacking events during portlet resizing or moving.